### PR TITLE
Double the numbers of records that search methods can return

### DIFF
--- a/src/main/java/se/raa/ksamsok/api/method/AbstractSearchMethod.java
+++ b/src/main/java/se/raa/ksamsok/api/method/AbstractSearchMethod.java
@@ -20,7 +20,7 @@ public abstract class AbstractSearchMethod extends AbstractAPIMethod {
 	/** parameternamnet som anges för att välja startRecord */
 	public static final String START_RECORD = "startRecord";
 	/** max antal träffar */
-	public static final int MAX_HITS_PER_PAGE = 500;
+	public static final int MAX_HITS_PER_PAGE = 1000;
 
 	protected String queryString;
 	protected String originalQueryString;


### PR DESCRIPTION
This increases the default number of records that most search methods can return. As a result, clients can access the same amount of data with not only fewer HTTP requests but also fewer IP payloads.

Good for everyone's electricity bill as well as the climate :deciduous_tree:.